### PR TITLE
Add logger to TaskTrackerNService for improved logging of pending rem…

### DIFF
--- a/src/be/TaskTracker.Infrastructure/Tasks/TaskTrackerNService.cs
+++ b/src/be/TaskTracker.Infrastructure/Tasks/TaskTrackerNService.cs
@@ -1,12 +1,12 @@
 ﻿using TaskTracker.Application.TaskReminders;
 
 namespace TaskTracker.Infrastructure.Tasks;
-public class TaskTrackerNService(ITaskDbContext taskDbContext) : ITaskTrackerNService
+public class TaskTrackerNService(ITaskDbContext taskDbContext, ILogger<TaskTrackerNService> logger) : ITaskTrackerNService
 {
     public async Task<List<TaskReminderDto>> GetPendingRemindersAsync(CancellationToken cancellationToken)
     {
         DateTimeOffset utcNow = DateTime.UtcNow;
-
+        logger.LogInformation("GetPendingRemindersAsync: Current App Server UTC time is {ServerUtcNow}", utcNow);
         return await taskDbContext.TaskReminders
             .AsNoTracking()
             .Where(r =>


### PR DESCRIPTION
This pull request introduces a logging enhancement to the `TaskTrackerNService` class to improve observability. A new `ILogger` dependency was added to the constructor, and a log statement was included in the `GetPendingRemindersAsync` method to record the current server UTC time.

Logging enhancement:

* [`src/be/TaskTracker.Infrastructure/Tasks/TaskTrackerNService.cs`](diffhunk://#diff-7831f26c84689567b7b6cfd5e3f9116709db1a5a8acd24c5c0103106e03024a6L4-R9): Added an `ILogger<TaskTrackerNService>` parameter to the constructor and included a log statement in the `GetPendingRemindersAsync` method to log the current server UTC time.…inders retrieval