### PR TITLE
Fix date format in notification replacements

### DIFF
--- a/src/be/TaskTracker.Service/Jobs/NotificationJob.cs
+++ b/src/be/TaskTracker.Service/Jobs/NotificationJob.cs
@@ -31,7 +31,7 @@ public class NotificationJob(ILogger<NotificationJob> logger, IBus bus, IService
                     Dictionary<string, string> replacements = new(){
                         {"{{TaskName}}", reminder.TaskName },
                         {"{{TaskDescription}}", reminder.TaskDescription },
-                        {"DueDate", reminder.DueDate.ToString("dd-MMM-yyyy hh:mm") }
+                        {"{{DueDate}}", reminder.DueDate.ToString("dd-MMM-yyyy hh:mm tt") }
                     };
                     await bus.Publish(new NotificationEvent(reminder.UsersEmail, "You have an upcoming Task", NotificationTypeEnum.UpcomingTaskReminder, replacements), cancellationToken);
                     await taskService.MarkReminderAsSentAsync(reminder.Id, cancellationToken);


### PR DESCRIPTION
This pull request includes a minor update to the `ProcessNotifications` method in `NotificationJob.cs`. The change ensures that the placeholder for the due date in notification messages is correctly formatted using double curly braces for consistency with other placeholders.

* [`src/be/TaskTracker.Service/Jobs/NotificationJob.cs`](diffhunk://#diff-01daa99522cfb4f8d73fdc35a2751a1684dbb14d7ec84bf945be1adc923f66ccL34-R34): Updated the `DueDate` placeholder in the `replacements` dictionary to use `{{DueDate}}` instead of `DueDate` for consistent templating.