### PR TITLE
Implement sidebar toggle functionality in MainLayout: enhance navigat…

### DIFF
--- a/src/fe/task-tracker-ui/src/pages/components/MainLayout.tsx
+++ b/src/fe/task-tracker-ui/src/pages/components/MainLayout.tsx
@@ -1,15 +1,26 @@
 import { Link, useLocation, Navigate } from 'react-router-dom';
 import { useSession } from '../../context/SessionContext';
+import { useState, useEffect } from 'react'; // Import useState and useEffect
 
 export default function MainLayout({ children }: { children: React.ReactNode }) {
   const { isAuthenticated, user, logout, bootstrapping } = useSession();
   const location = useLocation();
+  const [isSidebarOpen, setIsSidebarOpen] = useState(false);
 
   if (bootstrapping) return null;
 
   if (!isAuthenticated) {
     return <Navigate to="/login" replace state={{ from: location }} />;
   }
+
+  const toggleSidebar = () => setIsSidebarOpen(!isSidebarOpen);
+
+  useEffect(() => {
+    if (isSidebarOpen) {
+      setIsSidebarOpen(false);
+    }
+  }, [location.pathname]);
+
 
   const getRoles = (roleClaim: string | string[] | undefined) => {
     if (!roleClaim) return [];
@@ -39,8 +50,17 @@ export default function MainLayout({ children }: { children: React.ReactNode }) 
         { to: '/admin/user-tasks', label: "All Users' Tasks" },
       ].forEach(link => linkSet.set(link.to, link));
     }
+    
+    if (isAdmin && !linkSet.has('/dashboard')) {
+        linkSet.set('/dashboard', { to: '/dashboard', label: 'Dashboard' });
+    }
 
-    links = Array.from(linkSet.values());
+
+    links = Array.from(linkSet.values()).sort((a, b) => {
+        const order = ['/dashboard', '/tasks', "/admin/user-tasks", '/settings'];
+        return order.indexOf(a.to) - order.indexOf(b.to);
+    });
+
 
     if (!isUser && !isAdmin) {
       showLogout = false;
@@ -49,7 +69,14 @@ export default function MainLayout({ children }: { children: React.ReactNode }) 
 
   return (
     <div className="flex min-h-screen bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100">
-      <nav className="w-64 bg-purple-700 dark:bg-purple-900 text-white p-4 flex flex-col">
+      <nav
+        className={`
+          fixed inset-y-0 left-0 z-30 w-64 bg-purple-700 dark:bg-purple-900 text-white p-4
+          flex flex-col transition-transform duration-300 ease-in-out
+          ${isSidebarOpen ? 'translate-x-0' : '-translate-x-full'}
+          md:relative md:translate-x-0 md:flex md:w-64 
+        `}
+      >
         <div className="mb-8">
           <h1 className="text-2xl font-bold">TaskTracker</h1>
           <div className="mt-2 text-sm">
@@ -59,22 +86,48 @@ export default function MainLayout({ children }: { children: React.ReactNode }) 
         <ul className="space-y-2 flex-1">
           {links.map(link => (
             <li key={link.to}>
-              <Link to={link.to} className={`block py-2 px-4 rounded hover:bg-purple-600 dark:hover:bg-purple-800 ${
+              <Link
+                to={link.to}
+                className={`block py-2 px-4 rounded hover:bg-purple-600 dark:hover:bg-purple-800 ${
                   location.pathname === link.to ? 'bg-purple-800 dark:bg-purple-700' : ''
-                }`} >
+                }`}
+              >
                 {link.label}
               </Link>
             </li>
           ))}
         </ul>
         {showLogout && (
-          <button onClick={logout} className="w-full text-left py-2 px-4 rounded hover:bg-purple-600 dark:hover:bg-purple-800 mt-8" >
+          <button
+            onClick={logout}
+            className="w-full text-left py-2 px-4 rounded hover:bg-purple-600 dark:hover:bg-purple-800 mt-8"
+          >
             Logout
           </button>
         )}
       </nav>
 
-      <main className="flex-1 p-8">
+      {isSidebarOpen && (
+        <div
+          className="fixed inset-0 z-20 bg-black bg-opacity-50 md:hidden"
+          onClick={toggleSidebar}
+        ></div>
+      )}
+
+      <main className="flex-1 p-4 md:p-8 flex flex-col w-full overflow-x-hidden">
+        <div className="md:hidden mb-4">
+          <button
+            onClick={toggleSidebar}
+            className="p-2 rounded-md text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-purple-500"
+            aria-expanded={isSidebarOpen}
+            aria-controls="sidebar"
+            aria-label="Toggle navigation"
+          >
+            <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 6h16M4 12h16M4 18h16"></path>
+            </svg>
+          </button>
+        </div>
         {children}
       </main>
     </div>


### PR DESCRIPTION
This pull request introduces significant updates to the `MainLayout` component in the `TaskTracker` UI to enhance functionality and improve user experience. Key changes include the addition of a collapsible sidebar, dynamic navigation link sorting, and better responsiveness for mobile devices.

### Sidebar functionality and responsiveness:

* Introduced `useState` and `useEffect` hooks to manage the state of the sidebar (`isSidebarOpen`) and automatically close it when the route changes. (`[src/fe/task-tracker-ui/src/pages/components/MainLayout.tsxR3-R24](diffhunk://#diff-1339d7b92de6fe6f6e8c3df282737fb92fd58a50f42ba07463698758ddb15d8aR3-R24)`)
* Updated the sidebar's CSS classes to include animations for showing and hiding the sidebar, making it responsive for both desktop and mobile views. (`[src/fe/task-tracker-ui/src/pages/components/MainLayout.tsxL52-R79](diffhunk://#diff-1339d7b92de6fe6f6e8c3df282737fb92fd58a50f42ba07463698758ddb15d8aL52-R79)`)
* Added a toggle button for the sidebar in mobile view, including accessibility attributes (`aria-expanded`, `aria-controls`, and `aria-label`) for improved usability. (`[src/fe/task-tracker-ui/src/pages/components/MainLayout.tsxL62-R130](diffhunk://#diff-1339d7b92de6fe6f6e8c3df282737fb92fd58a50f42ba07463698758ddb15d8aL62-R130)`)
* Implemented a semi-transparent overlay that appears when the sidebar is open on mobile devices, allowing users to click outside the sidebar to close it. (`[src/fe/task-tracker-ui/src/pages/components/MainLayout.tsxL62-R130](diffhunk://#diff-1339d7b92de6fe6f6e8c3df282737fb92fd58a50f42ba07463698758ddb15d8aL62-R130)`)

### Navigation link enhancements:

* Added logic to dynamically sort navigation links based on a predefined order (`/dashboard`, `/tasks`, `/admin/user-tasks`, `/settings`) for better organization. (`[src/fe/task-tracker-ui/src/pages/components/MainLayout.tsxL43-R63](diffhunk://#diff-1339d7b92de6fe6f6e8c3df282737fb92fd58a50f42ba07463698758ddb15d8aL43-R63)`)
* Included a new link to the `/dashboard` route for admin users if it is not already present. (`[src/fe/task-tracker-ui/src/pages/components/MainLayout.tsxL43-R63](diffhunk://#diff-1339d7b92de6fe6f6e8c3df282737fb92fd58a50f42ba07463698758ddb15d8aL43-R63)`)